### PR TITLE
Improve compatibility with Bouncefix.

### DIFF
--- a/lib/fastclick.js
+++ b/lib/fastclick.js
@@ -594,7 +594,9 @@
 			// Don't send a synthetic click event if the target element is contained within a parent layer that was scrolled
 			// and this tap is being used to stop the scrolling (usually initiated by a fling - issue #42).
 			scrollParent = targetElement.fastClickScrollParent;
-			if (scrollParent && scrollParent.fastClickLastScrollTop !== scrollParent.scrollTop) {
+			var scrollTopDifference = scrollParent ? scrollParent.fastClickLastScrollTop - scrollParent.scrollTop : undefined;
+			// Allow for a 1px discrepancy, this improves compatibility with bouncefix libraries.
+			if (scrollParent && !(scrollTopDifference > -2 && scrollTopDifference < 2 )) {
 				return true;
 			}
 		}


### PR DESCRIPTION
Status: **Opened for visibility**
Reviewers: **@Helen-Mobify @scalvert**

This PR fixes an issue that appears when fastclick is paired with [bouncefix](https://github.com/jaridmargolin/bouncefix.js).

The issue is that when an iOS user is at the top of a scrollable element and attempts to tap on an element (link, button, etc.) bouncefix will [bump the scrollable element down 1px](https://github.com/jaridmargolin/bouncefix.js/blob/master/dist/bouncefix.js#L148) this then causes a [fastclick check to pass](https://github.com/ftlabs/fastclick/blob/master/lib/fastclick.js#L597) and the tap is ignored.
## Changes
- Changed check to allow for a 1px discrepancy, this both improves compatibility with bouncefix and maintains the functionality of the check.
